### PR TITLE
Changes needed to compile on OSX

### DIFF
--- a/vex.h
+++ b/vex.h
@@ -25,6 +25,21 @@
 extern "C" {
 #endif
 
+#ifdef YYPARSE_PARAM
+#if defined __STDC__ || defined __cplusplus
+int yyparse (void *YYPARSE_PARAM);
+#else
+int yyparse ();
+#endif
+#else /* ! YYPARSE_PARAM */
+#if defined __STDC__ || defined __cplusplus
+int yyparse (void);
+#else
+int yyparse ();
+#endif
+#endif /* ! YYPARSE_PARAM */
+
+  
 /* structure declarations */
 
 struct llist {


### PR DESCRIPTION
Fails to compile on OSX

> vex_get.c:39:6: error: implicit declaration of function 'yyparse' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
>
 > if(yyparse())
  >   ^
>1 error generated.
>make: *** [vex_get.o] Error 1


`gcc -v`
`Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/4.2.1`
`Apple clang version 13.0.0 (clang-1300.0.29.30)`
`Target: x86_64-apple-darwin20.6.0`
`Thread model: posix`
`InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin`

This may be an OSX issue, or gcc/clang version